### PR TITLE
variable was renamed

### DIFF
--- a/src/jdk.jpackager/unix/scripts/jpackager
+++ b/src/jdk.jpackager/unix/scripts/jpackager
@@ -99,7 +99,7 @@ fi
 # This is similar to "$@" except we had to strip out some arguments
 # that we don't want to be passed to the Java Packager.
 eval exec "$JAVA_CMD" ${DEBUG} ${MEMORY} ${JAVA_ARGS} \
-    --module-path ${JAVA_PACKAGER_PATH} \
+    --module-path ${JAVA_JPACKAGER_PATH} \
     --add-opens jdk.jlink/jdk.tools.jlink.internal.packager=jdk.jpackager \
     -m jdk.jpackager/jdk.jpackager.main.Main $args
     


### PR DESCRIPTION
`JAVA_PACKAGER_PATH` has been renamed to `JAVA_JPACKAGER_PATH`